### PR TITLE
Switch to OpenGLES 3

### DIFF
--- a/assets/levels/Intro.tscn
+++ b/assets/levels/Intro.tscn
@@ -146,13 +146,37 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.5, 1, 5 )
 [node name="PortalA" parent="PortalPair" index="0"]
 transform = Transform( 1, 4.50003e-15, 8.74228e-08, 7.10543e-15, -1, -2.98023e-08, -8.74228e-08, -2.98023e-08, 1, 5.9833, 3.18926, 15 )
 
-[node name="MeshInstance" parent="PortalPair/PortalA" index="2"]
+[node name="Back" parent="PortalPair/PortalA/Screen" index="0"]
+material_override = SubResource( 10 )
+
+[node name="Left" parent="PortalPair/PortalA/Screen" index="1"]
+material_override = SubResource( 10 )
+
+[node name="Right" parent="PortalPair/PortalA/Screen" index="2"]
+material_override = SubResource( 10 )
+
+[node name="Bottom" parent="PortalPair/PortalA/Screen" index="3"]
+material_override = SubResource( 10 )
+
+[node name="Top" parent="PortalPair/PortalA/Screen" index="4"]
 material_override = SubResource( 10 )
 
 [node name="PortalB" parent="PortalPair" index="1"]
 transform = Transform( 1, -8.29045e-16, -8.74228e-08, 1.77636e-15, -1, 2.98023e-08, 8.74228e-08, 2.98023e-08, 1, 12.9833, 3.18926, 15 )
 
-[node name="MeshInstance" parent="PortalPair/PortalB" index="2"]
+[node name="Back" parent="PortalPair/PortalB/Screen" index="0"]
+material_override = SubResource( 12 )
+
+[node name="Left" parent="PortalPair/PortalB/Screen" index="1"]
+material_override = SubResource( 12 )
+
+[node name="Right" parent="PortalPair/PortalB/Screen" index="2"]
+material_override = SubResource( 12 )
+
+[node name="Bottom" parent="PortalPair/PortalB/Screen" index="3"]
+material_override = SubResource( 12 )
+
+[node name="Top" parent="PortalPair/PortalB/Screen" index="4"]
 material_override = SubResource( 12 )
 
 [node name="PortalBorderA" type="Spatial" parent="."]

--- a/assets/scenes/Portal.tscn
+++ b/assets/scenes/Portal.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=2]
 
-[sub_resource type="Shader" id=6]
+[sub_resource type="Shader" id=1]
 resource_local_to_scene = true
 code = "shader_type spatial;
 render_mode unshaded;
@@ -16,11 +16,11 @@ void fragment() {
 }
 "
 
-[sub_resource type="ShaderMaterial" id=7]
+[sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
-shader = SubResource( 6 )
+shader = SubResource( 1 )
 
-[sub_resource type="QuadMesh" id=8]
+[sub_resource type="QuadMesh" id=3]
 size = Vector2( 4, 4 )
 
 [sub_resource type="BoxShape" id=4]
@@ -30,7 +30,7 @@ extents = Vector3( 2, 2, 0 )
 radius = 0.1
 height = 4.0
 
-[sub_resource type="BoxShape" id=9]
+[sub_resource type="BoxShape" id=6]
 
 [node name="Portal" type="Spatial"]
 
@@ -40,35 +40,36 @@ height = 4.0
 
 [node name="Back" type="MeshInstance" parent="Screen"]
 transform = Transform( -1, 0, -3.25841e-07, 0, 1, 0, 3.25841e-07, 0, -1, 0, 0, 0.5 )
-material_override = SubResource( 7 )
-mesh = SubResource( 8 )
+material_override = SubResource( 2 )
+mesh = SubResource( 3 )
 material/0 = null
 
 [node name="Left" type="MeshInstance" parent="Screen"]
 transform = Transform( -5.46392e-09, 0, -1, 0, 1, 0, 0.125, 0, -4.37114e-08, 2, 0, 0.25 )
-material_override = SubResource( 7 )
-mesh = SubResource( 8 )
+material_override = SubResource( 2 )
+mesh = SubResource( 3 )
 material/0 = null
 
 [node name="Right" type="MeshInstance" parent="Screen"]
 transform = Transform( -5.46392e-09, 0, 1, 0, 1, 0, -0.125, 0, -4.37114e-08, -2, 0, 0.25 )
-material_override = SubResource( 7 )
-mesh = SubResource( 8 )
+material_override = SubResource( 2 )
+mesh = SubResource( 3 )
 material/0 = null
 
 [node name="Bottom" type="MeshInstance" parent="Screen"]
 transform = Transform( -5.46392e-09, -1, -4.37114e-08, 0, -4.37114e-08, 1, -0.125, 4.37114e-08, 1.91069e-15, 0, -2, 0.25 )
-material_override = SubResource( 7 )
-mesh = SubResource( 8 )
+material_override = SubResource( 2 )
+mesh = SubResource( 3 )
 material/0 = null
 
 [node name="Top" type="MeshInstance" parent="Screen"]
 transform = Transform( -5.46392e-09, 1, -4.37114e-08, 0, -4.37114e-08, -1, -0.125, -4.37114e-08, 1.91069e-15, 0, 2, 0.25 )
-material_override = SubResource( 7 )
-mesh = SubResource( 8 )
+material_override = SubResource( 2 )
+mesh = SubResource( 3 )
 material/0 = null
 
 [node name="Viewport" type="Viewport" parent="."]
+keep_3d_linear = true
 
 [node name="Camera" type="Camera" parent="Viewport"]
 current = true
@@ -88,7 +89,7 @@ shape = SubResource( 5 )
 
 [node name="CollisionShapeLowMiddle" type="CollisionShape" parent="Border"]
 transform = Transform( 2, 0, 0, 0, 0.1, 0, 0, 0, 0.25, 0, -2.1, 0.25 )
-shape = SubResource( 9 )
+shape = SubResource( 6 )
 
 [node name="CollisionShapeLowBack" type="CollisionShape" parent="Border"]
 transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, -2.1, 0.5 )
@@ -100,7 +101,7 @@ shape = SubResource( 5 )
 
 [node name="CollisionShapeHighMiddle" type="CollisionShape" parent="Border"]
 transform = Transform( 2, 0, 0, 0, 0.1, 0, 0, 0, 0.25, 0, 2.1, 0.25 )
-shape = SubResource( 9 )
+shape = SubResource( 6 )
 
 [node name="CollisionShapeHighBack" type="CollisionShape" parent="Border"]
 transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 2.1, 0.5 )
@@ -112,7 +113,7 @@ shape = SubResource( 5 )
 
 [node name="CollisionShapeLeftMiddle" type="CollisionShape" parent="Border"]
 transform = Transform( 0.1, 0, 0, 0, 2, 0, 0, 0, 0.25, 2.1, 0, 0.25 )
-shape = SubResource( 9 )
+shape = SubResource( 6 )
 
 [node name="CollisionShapeLeftBack" type="CollisionShape" parent="Border"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -2.1, 0, 0.5 )
@@ -124,7 +125,7 @@ shape = SubResource( 5 )
 
 [node name="CollisionShapeRightMiddle" type="CollisionShape" parent="Border"]
 transform = Transform( 0.1, 0, 0, 0, 2, 0, 0, 0, 0.25, -2.1, 0, 0.25 )
-shape = SubResource( 9 )
+shape = SubResource( 6 )
 
 [node name="CollisionShapeRightBack" type="CollisionShape" parent="Border"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.1, 0, 0.5 )

--- a/assets/scenes/PortalPair.tscn
+++ b/assets/scenes/PortalPair.tscn
@@ -49,23 +49,47 @@ script = ExtResource( 1 )
 [node name="PortalA" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 0 )
 
+[node name="Back" parent="PortalA/Screen" index="0"]
+material_override = SubResource( 2 )
+
+[node name="Left" parent="PortalA/Screen" index="1"]
+material_override = SubResource( 2 )
+
+[node name="Right" parent="PortalA/Screen" index="2"]
+material_override = SubResource( 2 )
+
+[node name="Bottom" parent="PortalA/Screen" index="3"]
+material_override = SubResource( 2 )
+
+[node name="Top" parent="PortalA/Screen" index="4"]
+material_override = SubResource( 2 )
+
 [node name="Camera" parent="PortalA/Viewport" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 0 )
-
-[node name="MeshInstance" parent="PortalA" index="2"]
-material_override = SubResource( 2 )
 
 [node name="PortalB" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0 )
 
+[node name="Back" parent="PortalB/Screen" index="0"]
+material_override = SubResource( 4 )
+
+[node name="Left" parent="PortalB/Screen" index="1"]
+material_override = SubResource( 4 )
+
+[node name="Right" parent="PortalB/Screen" index="2"]
+material_override = SubResource( 4 )
+
+[node name="Bottom" parent="PortalB/Screen" index="3"]
+material_override = SubResource( 4 )
+
+[node name="Top" parent="PortalB/Screen" index="4"]
+material_override = SubResource( 4 )
+
 [node name="Camera" parent="PortalB/Viewport" index="0"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0 )
 
-[node name="MeshInstance" parent="PortalB" index="2"]
-material_override = SubResource( 4 )
 [connection signal="body_exited" from="PortalA/Area" to="." method="_on_portal_a_body_exited"]
 [connection signal="body_exited" from="PortalB/Area" to="." method="_on_portal_b_body_exited"]
 
 [editable path="PortalA"]
-
 [editable path="PortalB"]

--- a/assets/scripts/Player.gd
+++ b/assets/scripts/Player.gd
@@ -64,7 +64,7 @@ func _physics_process(delta):
 
 
 func pick_up_object() -> void:
-	var body: Holdable = $Body/Head/ForwardRay.get_collider()
+	var body = $Body/Head/ForwardRay.get_collider()
 	if not body is Holdable:
 		return
 	body.hold($Body/Head/ObjectHolder)

--- a/project.godot
+++ b/project.godot
@@ -75,5 +75,4 @@ common/physics_fps=120
 
 [rendering]
 
-quality/driver/driver_name="GLES2"
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
This changes the project to use OpenGLES 3, and enables an option on the portal viewport to prevent a whitish overlay on the portals. (I am confused as to why this didn't show up with OpenGLES 2.) It also does not typecast every object that the player tries to pick up to a `Holdable`, preventing an error in the debugger.